### PR TITLE
Refactor motor initializations

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumDrive.java
@@ -62,7 +62,6 @@ public class MecanumDrive {
         public RevHubOrientationOnRobot.UsbFacingDirection usbFacingDirection =
                 RevHubOrientationOnRobot.UsbFacingDirection.UP;
 
-
         // drive motor setup
         public String leftFrontDriveName = "leftFront";
         public String leftBackDriveName = "leftBack";
@@ -73,19 +72,6 @@ public class MecanumDrive {
         public DcMotorSimple.Direction leftBackDriveDirection = DcMotorSimple.Direction.REVERSE;
         public DcMotorSimple.Direction rightFrontDriveDirection = DcMotorSimple.Direction.FORWARD;
         public DcMotorSimple.Direction rightBackDriveDirection = DcMotorSimple.Direction.FORWARD;
-
-        // accesory motors setup
-        public String armName = "arm";
-        public DcMotorSimple.Direction armDirection = DcMotorSimple.Direction.FORWARD;
-
-        public String slideName = "slide";
-        public  DcMotorSimple.Direction slideDirection = DcMotorSimple.Direction.REVERSE;
-
-        public String hangerName = "linearActuator";
-        public  DcMotorSimple.Direction hangerDirection = DcMotorSimple.Direction.REVERSE;
-
-        public String clawName = "claw";
-
 
         // drive model parameters
         public double inPerTick = 1.0; // SparkFun OTOS Note: you can probably leave this at 1

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumDrive.java
@@ -81,6 +81,9 @@ public class MecanumDrive {
         public String slideName = "slide";
         public  DcMotorSimple.Direction slideDirection = DcMotorSimple.Direction.REVERSE;
 
+        public String hangerName = "linearActuator";
+        public  DcMotorSimple.Direction hangerDirection = DcMotorSimple.Direction.REVERSE;
+
         public String clawName = "claw";
 
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/PenguinsArm.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/PenguinsArm.java
@@ -61,9 +61,11 @@ public class PenguinsArm {
     final double ABSOLUTE_DELTA_ANGLE_DEGREES = 7.0;
 
 
-    private DcMotorEx Arm;
-    private DcMotorEx Slide;
-    private Servo Claw;
+    public DcMotorEx Arm;
+    public DcMotorEx Slide;
+    public Servo Claw;
+    public DcMotorEx Hanger;
+
     public PenguinsArm(HardwareMap hardwareMap, Telemetry telemetry1) {
         // Set up motors using MecanumDrive constants
         Arm = hardwareMap.get(DcMotorEx.class, DRIVE_PARAMS.armName);
@@ -74,17 +76,40 @@ public class PenguinsArm {
 
         Claw = hardwareMap.get(Servo.class, DRIVE_PARAMS.clawName);
 
+        Hanger = hardwareMap.get(DcMotorEx.class, DRIVE_PARAMS.hangerName);
+        Hanger.setDirection(DRIVE_PARAMS.hangerDirection);
+
         // The arm will hold its position when given 0.0 power
         Arm.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);
         Slide.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);
-        // Reset the arm's encoder position
-        Arm.setMode(DcMotorEx.RunMode.STOP_AND_RESET_ENCODER);
-        Slide.setMode(DcMotorEx.RunMode.STOP_AND_RESET_ENCODER);
+        Hanger.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);
+
+        // Reset the encoder positions
+        resetArmEncoder();
+        resetSlideEncoder();
+        resetHangerEncoder();
 
         // Allow the class to send data to telemetry
         telemetry = telemetry1;
     }
 
+    public void resetArmEncoder(){
+        // Reset the arm's encoder position
+        Arm.setMode(DcMotorEx.RunMode.STOP_AND_RESET_ENCODER);
+        Arm.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+    }
+
+    public void resetSlideEncoder() {
+        // Reset the slider's encoder position
+        Slide.setMode(DcMotorEx.RunMode.STOP_AND_RESET_ENCODER);
+        Slide.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+    }
+
+    public void resetHangerEncoder() {
+        // Reset the hanger's encoder position
+        Hanger.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        Hanger.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+    }
 
     // Method to check whether the robot will still be within size constraints after the desired movements
     public boolean getNewRobotLength(double deltaLengthInInches, double deltaAngleDeg) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/PenguinsArm.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/PenguinsArm.java
@@ -4,6 +4,7 @@ import androidx.annotation.NonNull;
 
 import com.acmerobotics.dashboard.telemetry.TelemetryPacket;
 import com.acmerobotics.roadrunner.Action;
+import com.qualcomm.robotcore.hardware.DcMotorSimple;
 import com.qualcomm.robotcore.hardware.Servo;
 import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
@@ -13,7 +14,22 @@ import com.qualcomm.robotcore.hardware.PIDFCoefficients;
 import org.firstinspires.ftc.robotcore.external.Telemetry;
 
 public class PenguinsArm {
-    public static MecanumDrive.Params DRIVE_PARAMS = new MecanumDrive.Params();
+    public static class Params {
+        // accesory motors setup
+        public String armName = "arm";
+        public DcMotorSimple.Direction armDirection = DcMotorSimple.Direction.FORWARD;
+
+        public String slideName = "slide";
+        public  DcMotorSimple.Direction slideDirection = DcMotorSimple.Direction.REVERSE;
+
+        public String hangerName = "linearActuator";
+        public  DcMotorSimple.Direction hangerDirection = DcMotorSimple.Direction.REVERSE;
+
+        public String clawName = "claw";
+    }
+
+
+    public static Params ARM_PARAMS = new Params();
     private Telemetry telemetry;
 
     // Known Slide/Arm/Claw positions
@@ -68,16 +84,16 @@ public class PenguinsArm {
 
     public PenguinsArm(HardwareMap hardwareMap, Telemetry telemetry1) {
         // Set up motors using MecanumDrive constants
-        Arm = hardwareMap.get(DcMotorEx.class, DRIVE_PARAMS.armName);
-        Arm.setDirection(DRIVE_PARAMS.armDirection);
+        Arm = hardwareMap.get(DcMotorEx.class, ARM_PARAMS.armName);
+        Arm.setDirection(ARM_PARAMS.armDirection);
 
-        Slide = hardwareMap.get(DcMotorEx.class, DRIVE_PARAMS.slideName);
-        Slide.setDirection(DRIVE_PARAMS.slideDirection);
+        Slide = hardwareMap.get(DcMotorEx.class, ARM_PARAMS.slideName);
+        Slide.setDirection(ARM_PARAMS.slideDirection);
 
-        Claw = hardwareMap.get(Servo.class, DRIVE_PARAMS.clawName);
+        Claw = hardwareMap.get(Servo.class, ARM_PARAMS.clawName);
 
-        Hanger = hardwareMap.get(DcMotorEx.class, DRIVE_PARAMS.hangerName);
-        Hanger.setDirection(DRIVE_PARAMS.hangerDirection);
+        Hanger = hardwareMap.get(DcMotorEx.class, ARM_PARAMS.hangerName);
+        Hanger.setDirection(ARM_PARAMS.hangerDirection);
 
         // The arm will hold its position when given 0.0 power
         Arm.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/PenguinsTeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/PenguinsTeleOp.java
@@ -5,7 +5,6 @@ import com.acmerobotics.dashboard.config.Config;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
-import com.qualcomm.robotcore.hardware.PIDFCoefficients;
 import com.qualcomm.robotcore.hardware.Servo;
 
 
@@ -15,41 +14,21 @@ public class PenguinsTeleOp extends LinearOpMode {
     //Initialize motors, servos, sensors, imus, etc.
     DcMotorEx m1, m2, m3, m4, Arm, Slide, Hanger;
     Servo Claw;
-    public static MecanumDrive.Params DRIVE_PARAMS = new MecanumDrive.Params();
-    public static PinpointDrive.Params PINPOINT_PARAMS = new PinpointDrive.Params();
-
-    public PenguinsArm penguinsArm = null;
-
-    public static double arm_p = 5;
-    public static double arm_i = 0.05;
-    public static double arm_d = 0;
-
-    public static double slide_p = 5;
-    public static double slide_i = 0.05;
-    public static double slide_d = 0;
-
-    // Built-in PID loops for RUN_TO_POSITION
-    public PIDFCoefficients armPID = new PIDFCoefficients(arm_p, arm_i, arm_d, 0);
-    public PIDFCoefficients slidePID = new PIDFCoefficients(slide_p, slide_i, slide_d, 0);
-
-    public PenguinsArm.ArmSlideToPosition autoArmSlider = null;
-    public TelemetryPacketOpMode telemetryPacket = null;
-
-
 
     // Custom Controls variables
     double virtualRightStickX = 0.0;
 
     // Set up constants for the size of the robot
-    int botWidth = 18;
+    public final double BOT_WIDTH = 18.0;
     // Set up constants for "preset" field locations
-    int STARTING_POSITION_Y = -70 + (botWidth/2);
-    int STARTING_POSITION_X = 9;
+    public final double STARTING_POSITION_Y = -70.0 + (BOT_WIDTH /2);
+    public final double STARTING_POSITION_X = 9.0;
+    public final double STARTING_ANGLE_DEG = 90.0;
 
     public void runOpMode() {
-        PinpointDrive drive = new PinpointDrive(hardwareMap, STARTING_POSITION_X, STARTING_POSITION_Y,90);
-        penguinsArm = new PenguinsArm(hardwareMap, telemetry);
-        telemetryPacket = new TelemetryPacketOpMode(telemetry);
+        PinpointDrive drive = new PinpointDrive(hardwareMap, STARTING_POSITION_X, STARTING_POSITION_Y, STARTING_ANGLE_DEG);
+        PenguinsArm penguinsArm = new PenguinsArm(hardwareMap, telemetry);
+        TelemetryPacketOpMode telemetryPacket = new TelemetryPacketOpMode(telemetry);
 
         //Define those motors and stuff
         //The string should be the name on the Driver Hub
@@ -70,6 +49,9 @@ public class PenguinsTeleOp extends LinearOpMode {
         //m2.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
         //m3.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
         //m4.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+
+        //This is to keep track of the current (if any) auto arm slide Action in progress
+        PenguinsArm.ArmSlideToPosition autoArmSlider = null;
 
         waitForStart();
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/PenguinsTeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/PenguinsTeleOp.java
@@ -1,19 +1,13 @@
 package org.firstinspires.ftc.teamcode;
 
 import com.acmerobotics.dashboard.config.Config;
+
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
-import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.PIDFCoefficients;
 import com.qualcomm.robotcore.hardware.Servo;
 
-import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit;
-import com.acmerobotics.roadrunner.Pose2d;
-import com.acmerobotics.roadrunner.PoseVelocity2d;
-import com.acmerobotics.roadrunner.ftc.GoBildaPinpointDriverRR;
-
-import java.util.Locale;
 
 @TeleOp
 @Config
@@ -46,75 +40,36 @@ public class PenguinsTeleOp extends LinearOpMode {
     // Custom Controls variables
     double virtualRightStickX = 0.0;
 
-
-    // Declare OpMode member for the Odometry Computer
-    GoBildaPinpointDriverRR odo;
+    // Set up constants for the size of the robot
+    int botWidth = 18;
+    // Set up constants for "preset" field locations
+    int STARTING_POSITION_Y = -70 + (botWidth/2);
+    int STARTING_POSITION_X = 9;
 
     public void runOpMode() {
+        PinpointDrive drive = new PinpointDrive(hardwareMap, STARTING_POSITION_X, STARTING_POSITION_Y,90);
         penguinsArm = new PenguinsArm(hardwareMap, telemetry);
         telemetryPacket = new TelemetryPacketOpMode(telemetry);
 
         //Define those motors and stuff
         //The string should be the name on the Driver Hub
-        m1 = (DcMotorEx) hardwareMap.dcMotor.get(DRIVE_PARAMS.leftFrontDriveName);
-        m2 = (DcMotorEx) hardwareMap.dcMotor.get(DRIVE_PARAMS.rightFrontDriveName);
-        m3 = (DcMotorEx) hardwareMap.dcMotor.get(DRIVE_PARAMS.leftBackDriveName);
-        m4 = (DcMotorEx) hardwareMap.dcMotor.get(DRIVE_PARAMS.rightBackDriveName);
-        Arm = (DcMotorEx) hardwareMap.dcMotor.get(DRIVE_PARAMS.armName);
-        Slide = (DcMotorEx) hardwareMap.dcMotor.get(DRIVE_PARAMS.slideName);
-        Hanger = (DcMotorEx) hardwareMap.dcMotor.get("linearActuator");
+        m1 = (DcMotorEx) drive.leftFront;
+        m2 = (DcMotorEx) drive.rightFront;
+        m3 = (DcMotorEx) drive.leftBack;
+        m4 = (DcMotorEx) drive.rightBack;;
 
-        Claw = (Servo) hardwareMap.servo.get("claw");
+        Arm = penguinsArm.Arm;;
+        Slide = penguinsArm.Slide;
+        Claw = penguinsArm.Claw;
+        Hanger = penguinsArm.Hanger;
 
-        //Set them to the correct modes
-        //This reverses the motor direction
-        m1.setDirection(DRIVE_PARAMS.leftFrontDriveDirection);
-        m2.setDirection(DRIVE_PARAMS.rightFrontDriveDirection);
-        m3.setDirection(DRIVE_PARAMS.leftBackDriveDirection);
-        m4.setDirection(DRIVE_PARAMS.rightBackDriveDirection);
-
-        Slide.setDirection(DRIVE_PARAMS.slideDirection);
-        Hanger.setDirection(DRIVE_PARAMS.slideDirection);
-
-
-        //This resets the encoder values when the code is initialized
-        m1.setMode(DcMotorEx.RunMode.STOP_AND_RESET_ENCODER);
-        m2.setMode(DcMotorEx.RunMode.STOP_AND_RESET_ENCODER);
-        m3.setMode(DcMotorEx.RunMode.STOP_AND_RESET_ENCODER);
-        m4.setMode(DcMotorEx.RunMode.STOP_AND_RESET_ENCODER);
-
-        Hanger.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
-        Slide.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
-        Arm.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
-
-        //This makes the wheels tense up and stay in position when it is not moving, opposite is FLOAT
-        m1.setZeroPowerBehavior(DcMotorEx.ZeroPowerBehavior.BRAKE);
-        m2.setZeroPowerBehavior(DcMotorEx.ZeroPowerBehavior.BRAKE);
-        m3.setZeroPowerBehavior(DcMotorEx.ZeroPowerBehavior.BRAKE);
-        m4.setZeroPowerBehavior(DcMotorEx.ZeroPowerBehavior.BRAKE);
-
-        Arm.setZeroPowerBehavior(DcMotorEx.ZeroPowerBehavior.BRAKE);
-        Slide.setZeroPowerBehavior(DcMotorEx.ZeroPowerBehavior.BRAKE);
-        Hanger.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);
-
+        // TODO: Figure out if this can be removed or should be added to MecanumDrive
         //This lets you look at encoder values while the OpMode is active
         //If you have a STOP_AND_RESET_ENCODER, make sure to put this below it
-        m1.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
-        m2.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
-        m3.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
-        m4.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
-
-        Hanger.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
-        Slide.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
-        Arm.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
-
-
-        // Pinpoint computer setup
-        odo = hardwareMap.get(GoBildaPinpointDriverRR.class, PINPOINT_PARAMS.pinpointDeviceName);
-        odo.setOffsets(DistanceUnit.MM.fromInches(PINPOINT_PARAMS.xOffset), DistanceUnit.MM.fromInches(PINPOINT_PARAMS.yOffset));
-        odo.setEncoderResolution(PINPOINT_PARAMS.encoderResolution);
-        odo.setEncoderDirections(PINPOINT_PARAMS.xDirection, PINPOINT_PARAMS.yDirection);
-        odo.resetPosAndIMU();
+        //m1.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        //m2.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        //m3.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        //m4.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
 
         waitForStart();
 
@@ -160,11 +115,6 @@ public class PenguinsTeleOp extends LinearOpMode {
             m2.setPower(p2);
             m3.setPower(p3);
             m4.setPower(p4);
-
-
-
-
-
 
             // Arm Input Code
             double desiredArmPower = 0.0;
@@ -250,42 +200,18 @@ public class PenguinsTeleOp extends LinearOpMode {
             // EMERGENCY encoder reset sequence
             if ((gamepad1.start && gamepad1.back) || (gamepad2.start && gamepad2.back)) {
                 // In case of "emergency," reset all encoders
-                Slide.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
-                Arm.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
-
-                Slide.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
-                Arm.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+                penguinsArm.resetArmEncoder();
+                penguinsArm.resetSlideEncoder();
+                penguinsArm.resetHangerEncoder();
 
                 telemetry.addLine("Reset encoders");
             }
 
-
-
-            odo.update();
-
-            // gets the current Position (x & y in inches, and heading in degrees) of the robot, and prints it.
-            Pose2d pos = odo.getPositionRR();
-            String data = String.format(Locale.US, "{X: %.3f, Y: %.3f, H: %.3f}", pos.position.x, pos.position.y, Math.toDegrees(pos.heading.toDouble()));
-            telemetry.addData("Position", data);
-
-            // gets the current Velocity (x & y in inches/sec and heading in degrees/sec) and prints it.
-            PoseVelocity2d vel = odo.getVelocityRR();
-            String velocity = String.format(Locale.US,"{XVel: %.3f, YVel: %.3f, HVel: %.3f}", vel.linearVel.x, vel.linearVel.y, Math.toDegrees(vel.angVel));
-            telemetry.addData("Velocity", velocity);
-            telemetry.addData("Pinpoint Frequency", odo.getFrequency()); //prints/gets the current refresh rate of the Pinpoint
-
-            /*
-            Gets the Pinpoint device status. Pinpoint can reflect a few states. But we'll primarily see
-            READY: the device is working as normal
-            CALIBRATING: the device is calibrating and outputs are put on hold
-            NOT_READY: the device is resetting from scratch. This should only happen after a power-cycle
-            FAULT_NO_PODS_DETECTED - the device does not detect any pods plugged in
-            FAULT_X_POD_NOT_DETECTED - The device does not detect an X pod plugged in
-            FAULT_Y_POD_NOT_DETECTED - The device does not detect a Y pod plugged in
-            */
-            telemetry.addData("Status", odo.getDeviceStatus());
-
+            // Have each module add debug data to the telemetry object so it can be sent to the
+            // driver's station
+            drive.addDebugData(telemetry);
             penguinsArm.addDebugData();
+
             telemetry.update();
 
         } // opModeActive loop ends

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/PenguinsTeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/PenguinsTeleOp.java
@@ -53,10 +53,10 @@ public class PenguinsTeleOp extends LinearOpMode {
 
         //Define those motors and stuff
         //The string should be the name on the Driver Hub
-        m1 = (DcMotorEx) drive.leftFront;
-        m2 = (DcMotorEx) drive.rightFront;
-        m3 = (DcMotorEx) drive.leftBack;
-        m4 = (DcMotorEx) drive.rightBack;;
+        m1 = drive.leftFront;
+        m2 = drive.rightFront;
+        m3 = drive.leftBack;
+        m4 = drive.rightBack;;
 
         Arm = penguinsArm.Arm;;
         Slide = penguinsArm.Slide;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/PinpointDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/PinpointDrive.java
@@ -8,10 +8,14 @@ import com.acmerobotics.roadrunner.ftc.FlightRecorder;
 import com.acmerobotics.roadrunner.ftc.GoBildaPinpointDriver;
 import com.acmerobotics.roadrunner.ftc.GoBildaPinpointDriverRR;
 import com.qualcomm.robotcore.hardware.HardwareMap;
+
+import org.firstinspires.ftc.robotcore.external.Telemetry;
 import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
 import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit;
 import org.firstinspires.ftc.robotcore.external.navigation.Pose2D;
 import org.firstinspires.ftc.teamcode.messages.PoseMessage;
+
+import java.util.Locale;
 
 /**
  * Experimental extension of MecanumDrive that uses the Gobilda Pinpoint sensor for localization.
@@ -94,6 +98,14 @@ public class PinpointDrive extends MecanumDrive {
 
         pinpoint.setPosition(pose);
     }
+
+    // Alternate constructor to allows users of this class to not be dependent on RR's pose type
+    public PinpointDrive(HardwareMap hardwareMap, double poseX, double poseY, double poseAngleDeg) {
+        // Call the main constructor
+        this(hardwareMap, new Pose2d(poseX, poseY, Math.toRadians(poseAngleDeg)));
+    }
+
+
     @Override
     public PoseVelocity2d updatePoseEstimate() {
         if (lastPinpointPose != pose) {
@@ -121,6 +133,33 @@ public class PinpointDrive extends MecanumDrive {
         FlightRecorder.write("PINPOINT_STATUS",pinpoint.getDeviceStatus());
 
         return pinpoint.getVelocityRR();
+    }
+
+    public void addDebugData(Telemetry telemetry){
+        // gets the current Position (x & y in inches, and heading in degrees) of the robot
+        PoseVelocity2d vel = updatePoseEstimate();
+
+        String data = String.format(Locale.US, "{X: %.3f, Y: %.3f, H: %.3f}",
+                lastPinpointPose.position.x,
+                lastPinpointPose.position.y,
+                Math.toDegrees(lastPinpointPose.heading.toDouble()));
+        telemetry.addData("Position", data);
+
+        // gets the current Velocity (x & y in inches/sec and heading in degrees/sec) and prints it.
+        String velocity = String.format(Locale.US,"{XVel: %.3f, YVel: %.3f, HVel: %.3f}", vel.linearVel.x, vel.linearVel.y, Math.toDegrees(vel.angVel));
+        telemetry.addData("Velocity", velocity);
+        telemetry.addData("Pinpoint Frequency", pinpoint.getFrequency()); //prints/gets the current refresh rate of the Pinpoint
+
+            /*
+            Gets the Pinpoint device status. Pinpoint can reflect a few states. But we'll primarily see
+            READY: the device is working as normal
+            CALIBRATING: the device is calibrating and outputs are put on hold
+            NOT_READY: the device is resetting from scratch. This should only happen after a power-cycle
+            FAULT_NO_PODS_DETECTED - the device does not detect any pods plugged in
+            FAULT_X_POD_NOT_DETECTED - The device does not detect an X pod plugged in
+            FAULT_Y_POD_NOT_DETECTED - The device does not detect a Y pod plugged in
+            */
+        telemetry.addData("Status", pinpoint.getDeviceStatus());
     }
 
 


### PR DESCRIPTION
I've been thinking that it would be great if the main OpMode and Auton files could reference common code to setup the motors keeping their logic less tied to the hardware details.  This would ensure that if something changes (like a motor name) it only needs to be changed in one place.  It also provides better abstraction and separation of concerns.

In theory there is no functional difference between this code and the current code, it's just been rearranged a bit.
